### PR TITLE
feature(handle-large-file-retrieval): Leveraged concurrency to handle large file retrival

### DIFF
--- a/internal/service/file_service.go
+++ b/internal/service/file_service.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"math"
 	"strings"
+	"sync"
 
 	"github.com/ashtishad/fileverse/internal/domain"
 	"github.com/ashtishad/fileverse/internal/infra/storage"
@@ -51,7 +53,9 @@ func (s *DefaultFileService) SaveFile(ctx context.Context, fileName string, file
 	return fileRespDTO, nil
 }
 
-// RetrieveFile handles the logic for retrieving an existing file.
+// RetrieveFile fetches the contents of a file identified by fileID in concurrent file chunks,
+// Leverages goroutines to retrieve each chunk from IPFS and assembles them into a single byte slice in correct order,
+// If successful, it returns the complete file content as []byte, otherwise an error.
 func (s *DefaultFileService) RetrieveFile(ctx context.Context, fileID string) ([]byte, utils.APIError) {
 	fileMeta, apiErr := s.repo.FindMeta(ctx, fileID)
 	if apiErr != nil {
@@ -59,18 +63,34 @@ func (s *DefaultFileService) RetrieveFile(ctx context.Context, fileID string) ([
 		return nil, apiErr
 	}
 
-	fileReader, err := s.ipfs.RetrieveFile(fileMeta.IPFSHash)
-	if err != nil {
-		s.logger.Error("failed to retrieve file from IPFS", "hash", fileMeta.IPFSHash, "error", err)
-		return nil, utils.InternalServerError("failed to retrieve file from IPFS", err)
-	}
-	defer fileReader.Close()
+	numChunks := int(math.Ceil(float64(fileMeta.Size) / float64(utils.FileChunkSize)))
 
-	fileContent, err := io.ReadAll(fileReader)
-	if err != nil {
-		s.logger.Error("failed to read file content", "hash", fileMeta.IPFSHash, "error", err)
-		return nil, utils.InternalServerError("failed to read file content", err)
+	fileContent := make([]byte, fileMeta.Size)
+	var wg sync.WaitGroup
+	wg.Add(numChunks)
+
+	for i := 0; i < numChunks; i++ {
+		go func(chunkNum int) {
+			defer wg.Done()
+
+			offset := chunkNum * utils.FileChunkSize
+			size := utils.FileChunkSize
+
+			if chunkNum == numChunks-1 {
+				size = int(fileMeta.Size) - offset
+			}
+
+			chunk, err := s.ipfs.RetrieveFileChunk(fileMeta.IPFSHash, int64(offset), int64(size))
+			if err != nil {
+				s.logger.Error("failed to retrieve file chunk from IPFS", "chunkNum", chunkNum, "error", err)
+				return
+			}
+
+			copy(fileContent[offset:], chunk)
+		}(i)
 	}
+
+	wg.Wait()
 
 	return fileContent, nil
 }

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,0 +1,3 @@
+package utils
+
+const FileChunkSize = 10 * 1024 * 1024 // 10 MB


### PR DESCRIPTION
Strategy
----------
* fetch file chunks from ipfs storage.
* assemble together in correct order.

Discussion
----------
**Haven't seen significant improvement, as IPFS is designed to handle large files both for upload and retrieval efficiently.**

Chunking: When we add a large file to IPFS, it automatically breaks the file into smaller chunks, typically about 256KB each. These chunks are then stored in a Merkle DAG, a tree-like structure where each leaf node represents a block of data (a chunk of the file) and each non-leaf node contains the cryptographic hashes of its children nodes.

Content Addressing: Each chunk is identified by its hash, which is a unique fingerprint of its contents. This means that if two files share a common piece of data, they will share the same hash and, therefore, don't need to store or transfer that chunk twice.

Deduplication: Because each piece of data has a unique hash, IPFS can easily detect duplicate data. This means that if we try to add identical files or files with overlapping content to IPFS, it will store only one copy of each unique chunk, saving space and reducing redundancy.

Retrieval: When we request a file, IPFS uses the Merkle DAG to find all the chunks that make up that file. Then it retrieves each chunk from the nearest location among our node, other IPFS nodes, or even from a cached version if available. IPFS's networking layer is designed to retrieve these chunks in parallel, which means that even if a large file is spread out across many different nodes, we can download it quickly.

Efficiency: This structure also allows for efficient updates to files. If a file is updated, only the chunks that have changed need to be re-uploaded and re-distributed. This is especially powerful for large datasets where changes may be frequent but small relative to the size of the entire dataset.