### PR TITLE
Chore/improve uploading retrieving large file with streaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,5 @@ run:
 	export DB_HOST=127.0.0.1 \
 	export DB_PORT=5432 \
 	export DB_NAME=fileverse \
+	export IPFS_ADDR=127.0.0.1:5001 \
 && go run main.go

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -24,7 +24,7 @@ func Start() {
 
 	dbClient := database.GetDBClient(logger)
 
-	ipfsClient := storage.NewIPFSStorage("localhost:5001")
+	ipfsClient := storage.NewIPFSStorage(os.Getenv("IPFS_ADDR"))
 
 	fileRepositoryDB := domain.NewFileRepoDB(dbClient, logger)
 
@@ -32,7 +32,7 @@ func Start() {
 
 	router := gin.Default()
 
-	fileHandlers := FileHandlers{s: fileService}
+	fileHandlers := FileHandlers{s: fileService, l: logger}
 
 	router.POST("/upload", fileHandlers.SaveFileHandler)
 	router.GET("/file/:fileId", fileHandlers.GetFileHandler)

--- a/cmd/app/handlers.go
+++ b/cmd/app/handlers.go
@@ -14,16 +14,11 @@ type FileHandlers struct {
 	l *slog.Logger
 }
 
-// SaveFileHandler handles the HTTP request for saving file metadata.
+// SaveFileHandler handles the HTTP request for saving file metadata to database and file to ipfs storage.
 func (fh *FileHandlers) SaveFileHandler(c *gin.Context) {
-	if err := c.Request.ParseMultipartForm(32 << 20); err != nil { // 32 MB max memory
-		c.JSON(http.StatusBadRequest, gin.H{"error": "File upload error: " + err.Error()})
-		return
-	}
-
 	file, header, err := c.Request.FormFile("file")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "File retrieval error: " + err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file upload error: " + err.Error()})
 		return
 	}
 	defer file.Close()
@@ -33,16 +28,11 @@ func (fh *FileHandlers) SaveFileHandler(c *gin.Context) {
 
 	fileResp, apiErr := fh.s.SaveFile(c.Request.Context(), fileName, fileSize, file)
 	if apiErr != nil {
-		c.JSON(apiErr.Code(), gin.H{
-			"error": apiErr.Error(),
-		})
-
+		c.JSON(apiErr.Code(), gin.H{"error": apiErr.Error()})
 		return
 	}
 
-	c.JSON(http.StatusCreated, gin.H{
-		"file": fileResp,
-	})
+	c.JSON(http.StatusCreated, gin.H{"file": fileResp})
 }
 
 // GetFileHandler handles the HTTP request for retrieving file content.

--- a/pkg/utils/sanity_check.go
+++ b/pkg/utils/sanity_check.go
@@ -18,6 +18,7 @@ func SanityCheck(l *slog.Logger) {
 		"DB_HOST":   "127.0.0.1",
 		"DB_PORT":   "5432",
 		"DB_NAME":   "fileverse",
+		"IPFS_ADDR": "127.0.0.1:5001",
 	}
 
 	for key, defaultValue := range defaultEnvVars {


### PR DESCRIPTION
**Key Changes:**

- **File Uploads:**
  - Removed the `ParseMultipartForm` to avoid buffering large files in memory.
  - Files are now streamed directly from the request to IPFS, facilitating the handling of files larger than the previous 32MB limit.

- **File Retrieval:**
  - Altered the retrieval logic to stream files directly from IPFS to the client, rather than loading the entire file content into memory before sending.
  - This change mitigates memory-related issues and allows for the efficient download of large files.